### PR TITLE
Feature/ml 19:  Add NER predict

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.formatting.provider": "black"
+}

--- a/README.md
+++ b/README.md
@@ -16,8 +16,23 @@ Once you are satisfied with the performance, in one line of code, **serve** the 
 ```bash
 git clone https://github.com/kili-technology/automl.git
 cd automl
+git submodule update --init
+```
+
+If you are using `pip`:
+```bash
 pip install -r requirements.txt
 ```
+if you are using `conda`:
+```bash
+conda install --file requirements.txt
+```
+
+then install the submodule requirements:
+```bash
+pip install -r utils/ultralytics/yolov5/requirements.txt
+```
+
 
 ## Usage
 

--- a/predict.py
+++ b/predict.py
@@ -1,15 +1,124 @@
-import click
+from glob import glob
+import os
+from typing import Optional, List, Dict
+from xmlrpc.client import boolean
 
-from utils.helpers import kili_print
+import click
+from kili.client import Kili
+
+from utils.constants import (
+    ContentInput,
+    HOME,
+    InputType,
+    MLTask,
+    ModelFramework,
+    ModelRepository,
+)
+from utils.helpers import get_assets, get_project, kili_print
+
+
+def predict_ner(
+    api_key: str,
+    assets: List[Dict],
+    job_name: str,
+    project_id: str,
+    model_path: Optional[str],
+    verbose: int,
+):
+    if model_path is None:
+        path_project_models = os.path.join(
+            HOME, project_id, job_name, "*", "model", "*", "*"
+        )
+        paths_project_sorted = sorted(glob(path_project_models), reverse=True)
+        model_path = None
+        while len(paths_project_sorted):
+            path_model_candidate = paths_project_sorted.pop(0)
+            if len(os.listdir(path_model_candidate)) > 0 and os.path.exists(
+                os.path.join(path_model_candidate, "pytorch_model.bin")
+            ):
+                model_path = path_model_candidate
+                kili_print(f"Trained model found in path: {model_path}")
+                break
+        if model_path is None:
+            raise Exception("No trained model found for job {job}. Exiting ...")
+    split_path = os.path.normpath(model_path).split(os.path.sep)
+    if split_path[-4] == ModelRepository.HuggingFace:
+        model_repository = ModelRepository.HuggingFace
+        kili_print(f"Model base repository: {model_repository}")
+    else:
+        raise ValueError("Unknown model base repository")
+    if split_path[-2] in [ModelFramework.PyTorch, ModelFramework.Tensorflow]:
+        model_framework = split_path[-2]
+        kili_print(f"Model framework: {model_framework}")
+    else:
+        raise ValueError("Unknown model framework")
+    if model_repository == ModelRepository.HuggingFace:
+        from utils.huggingface.predict import huggingface_predict_ner
+
+        return huggingface_predict_ner(
+            api_key, assets, model_framework, model_path, job_name, verbose=verbose
+        )
 
 
 @click.command()
-@click.option('--api-key', default='', help='Kili API Key')
-@click.option('--project-id', default='', help='Kili project ID')
-def main(api_key: str, project_id: str):
-    '''
-    '''
-    kili_print('not implemented yet')
+@click.option("--api-key", default=os.environ["KILI_API_KEY"], help="Kili API Key")
+@click.option("--project-id", required=True, help="Kili project ID")
+@click.option(
+    "--label-types",
+    default="DEFAULT,REVIEW",
+    help="Comma separated list Kili specific label types to select (among DEFAULT, REVIEW, PREDICTION), defaults to 'DEFAULT,REVIEW'",
+)
+@click.option(
+    "--dry-run",
+    default=None,
+    is_flag=True,
+    help="Runs the predictions but do not save them into the Kili project",
+)
+@click.option(
+    "--from-model",
+    default=None,
+    help="Runs the predictions using a specified model path",
+)
+@click.option(
+    "--verbose",
+    default=0,
+    help="Verbose level",
+)
+def main(
+    api_key: str,
+    project_id: str,
+    label_types: str,
+    dry_run: bool,
+    from_model: Optional[str],
+    verbose: bool,
+):
+
+    kili = Kili(api_key=api_key)
+    input_type, jobs = get_project(kili, project_id)
+    assets = get_assets(kili, project_id, label_types.split(","))
+
+    for job_name, job in jobs.items():
+        content_input = job.get("content", {}).get("input")
+        ml_task = job.get("mlTask")
+
+        if (
+            content_input == ContentInput.Radio
+            and input_type == InputType.Text
+            and ml_task == MLTask.NamedEntitiesRecognition
+        ):
+            json_responses = predict_ner(
+                api_key, assets, job_name, project_id, from_model, verbose=verbose
+            )
+
+            if not dry_run:
+                kili.create_predictions(
+                    project_id,
+                    external_id_array=[a["externalId"] for a in assets],
+                    json_response_array=json_responses,
+                    model_name_array=["Kili AutoML"] * len(assets),
+                )
+        else:
+            kili_print("not implemented yet")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 click
 datasets
 kili
-nltk
+nltk>=3.3
 numpy
 requests
-sklearn
+scikit-learn
 tabulate
 tensorflow
 termcolor

--- a/train.py
+++ b/train.py
@@ -1,121 +1,229 @@
 import os
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
 
 import click
 from kili.client import Kili
 from tabulate import tabulate
 
-from utils.constants import ContentInput, HOME, InputType, MLTask, \
-    ModelFramework, ModelName, ModelRepository, Tool
+from utils.constants import (
+    ContentInput,
+    HOME,
+    InputType,
+    MLTask,
+    ModelFramework,
+    ModelName,
+    ModelRepository,
+    Tool,
+)
 from utils.helpers import get_assets, get_project, kili_print, set_default
-from utils.huggingface.train import huggingface_train_ner, \
-    huggingface_train_text_classification_single
-from utils.ultralytics.train import ultralytics_train_yolov5
 
-os.environ['TOKENIZERS_PARALLELISM'] = 'false'
-os.environ['WANDB_DISABLED'] = 'true'
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+os.environ["WANDB_DISABLED"] = "true"
 
 
 def train_image_bounding_box(
-        api_key, assets, job, job_name, 
-        model_framework, model_name, model_repository, project_id):
-    '''
-    '''
-    model_repository = set_default(model_repository, ModelRepository.PyTorchHub, 
-        'model_repository', [ModelRepository.PyTorchHub])
+    api_key,
+    assets,
+    job,
+    job_name,
+    model_framework,
+    model_name,
+    model_repository,
+    project_id,
+):
+    from utils.ultralytics.train import ultralytics_train_yolov5
+
+    model_repository = set_default(
+        model_repository,
+        ModelRepository.PyTorchHub,
+        "model_repository",
+        [ModelRepository.PyTorchHub],
+    )
     path = os.path.join(HOME, project_id, job_name, model_repository)
     if model_repository == ModelRepository.PyTorchHub:
-        model_framework = set_default(model_framework, ModelFramework.PyTorch, 
-            'model_framework', [ModelFramework.PyTorch])
-        model_name = set_default(model_name, ModelName.YoloV5, 
-            'model_name', [ModelName.YoloV5])
+        model_framework = set_default(
+            model_framework,
+            ModelFramework.PyTorch,
+            "model_framework",
+            [ModelFramework.PyTorch],
+        )
+        model_name = set_default(
+            model_name, ModelName.YoloV5, "model_name", [ModelName.YoloV5]
+        )
         return ultralytics_train_yolov5(
-            api_key, assets, job, job_name, model_framework, model_name, path)
+            api_key, assets, job, job_name, model_framework, model_name, path
+        )
 
 
 def train_ner(
-        api_key, assets, job, job_name, 
-        model_framework, model_name, model_repository, project_id):
-    '''
-    '''
-    model_repository = set_default(model_repository, ModelRepository.HuggingFace, 
-        'model_repository', [ModelRepository.HuggingFace])
+    api_key,
+    assets,
+    job,
+    job_name,
+    model_framework,
+    model_name,
+    model_repository,
+    project_id,
+):
+    from utils.huggingface.train import huggingface_train_ner
+    import nltk
+
+    nltk.download("punkt")
+    model_repository = set_default(
+        model_repository,
+        ModelRepository.HuggingFace,
+        "model_repository",
+        [ModelRepository.HuggingFace],
+    )
     path = os.path.join(HOME, project_id, job_name, model_repository)
     if model_repository == ModelRepository.HuggingFace:
-        model_framework = set_default(model_framework, ModelFramework.PyTorch, 
-            'model_framework', [ModelFramework.PyTorch, ModelFramework.Tensorflow])
-        model_name = set_default(model_name, ModelName.BertBaseMultilingualCased, 
-            'model_name', [ModelName.BertBaseMultilingualCased])
+        model_framework = set_default(
+            model_framework,
+            ModelFramework.PyTorch,
+            "model_framework",
+            [ModelFramework.PyTorch, ModelFramework.Tensorflow],
+        )
+        model_name = set_default(
+            model_name,
+            ModelName.BertBaseMultilingualCased,
+            "model_name",
+            [
+                ModelName.BertBaseMultilingualCased,
+                ModelName.DistilbertBaseCased,
+            ],
+        )
         return huggingface_train_ner(
-            api_key, assets, job, job_name, model_framework, model_name, path)
+            api_key, assets, job, job_name, model_framework, model_name, path
+        )
 
 
 def train_text_classification_single(
-        api_key, assets, job, job_name, 
-        model_framework, model_name, model_repository, project_id) -> float:
-    '''
-    '''
-    model_repository = set_default(model_repository, ModelRepository.HuggingFace, 
-        'model_repository', [ModelRepository.HuggingFace])
+    api_key,
+    assets,
+    job,
+    job_name,
+    model_framework,
+    model_name,
+    model_repository,
+    project_id,
+) -> float:
+    """ """
+    import nltk
+
+    nltk.download("punkt")
+    from utils.huggingface.train import huggingface_train_text_classification_single
+
+    model_repository = set_default(
+        model_repository,
+        ModelRepository.HuggingFace,
+        "model_repository",
+        [ModelRepository.HuggingFace],
+    )
     path = os.path.join(HOME, project_id, job_name, model_repository)
     if model_repository == ModelRepository.HuggingFace:
-        model_framework = set_default(model_framework, ModelFramework.PyTorch, 
-            'model_framework', [ModelFramework.PyTorch, ModelFramework.Tensorflow])
-        model_name = set_default(model_name, ModelName.BertBaseMultilingualCased, 
-            'model_name', [ModelName.BertBaseMultilingualCased])
+        model_framework = set_default(
+            model_framework,
+            ModelFramework.PyTorch,
+            "model_framework",
+            [ModelFramework.PyTorch, ModelFramework.Tensorflow],
+        )
+        model_name = set_default(
+            model_name,
+            ModelName.BertBaseMultilingualCased,
+            "model_name",
+            [ModelName.BertBaseMultilingualCased],
+        )
         return huggingface_train_text_classification_single(
-            api_key, assets, job, job_name, model_framework, model_name, path)
-
-
+            api_key, assets, job, job_name, model_framework, model_name, path
+        )
 
 
 @click.command()
-@click.option('--api-key', default=None, help='Kili API Key')
-@click.option('--model-framework', default=None, help='Model framework (eg. pytorch, tensorflow)')
-@click.option('--model-name', default=None, help='Model name (eg. bert-base-cased)')
-@click.option('--model-repository', default=None, help='Model repository (eg. huggingface)')
-@click.option('--project-id', default=None, help='Kili project ID')
-def main(api_key: str, model_framework: str, model_name: str, model_repository: str, project_id: str):
-    '''
-    '''
+@click.option("--api-key", default=os.environ["KILI_API_KEY"], help="Kili API Key")
+@click.option(
+    "--model-framework", default=None, help="Model framework (eg. pytorch, tensorflow)"
+)
+@click.option("--model-name", default=None, help="Model name (eg. bert-base-cased)")
+@click.option(
+    "--model-repository", default=None, help="Model repository (eg. huggingface)"
+)
+@click.option("--project-id", default=None, help="Kili project ID")
+@click.option(
+    "--label-types",
+    default=None,
+    help="Comma separated list Kili specific label types to select (among DEFAULT, REVIEW, PREDICTION)",
+)
+def main(
+    api_key: str,
+    model_framework: str,
+    model_name: str,
+    model_repository: str,
+    project_id: str,
+    label_types: str,
+):
+    """ """
     kili = Kili(api_key=api_key)
     input_type, jobs = get_project(kili, project_id)
-    assets = get_assets(kili, project_id)
+    assets = get_assets(
+        kili, project_id, label_types.split(",") if label_types else None
+    )
     training_losses = []
     for job_name, job in jobs.items():
-        content_input = job.get('content', {}).get('input')
-        ml_task = job.get('mlTask')
-        tools = job.get('tools')
+        content_input = job.get("content", {}).get("input")
+        ml_task = job.get("mlTask")
+        tools = job.get("tools")
         training_loss = None
-        if content_input == ContentInput.Radio \
-                and input_type == InputType.Text \
-                and ml_task == MLTask.Classification:
+        if (
+            content_input == ContentInput.Radio
+            and input_type == InputType.Text
+            and ml_task == MLTask.Classification
+        ):
             training_loss = train_text_classification_single(
-                api_key, assets, job, job_name, 
-                model_framework, model_name, model_repository, project_id)
-        elif content_input == ContentInput.Radio \
-                and input_type == InputType.Text \
-                and ml_task == MLTask.NamedEntitiesRecognition:
+                api_key,
+                assets,
+                job,
+                job_name,
+                model_framework,
+                model_name,
+                model_repository,
+                project_id,
+            )
+        elif (
+            content_input == ContentInput.Radio
+            and input_type == InputType.Text
+            and ml_task == MLTask.NamedEntitiesRecognition
+        ):
             training_loss = train_ner(
-                api_key, assets, job, job_name, 
-                model_framework, model_name, model_repository, project_id)
-        elif content_input == ContentInput.Radio \
-                and input_type == InputType.Image \
-                and ml_task == MLTask.ObjectDetection \
-                and Tool.Rectangle in tools:
+                api_key,
+                assets,
+                job,
+                job_name,
+                model_framework,
+                model_name,
+                model_repository,
+                project_id,
+            )
+        elif (
+            content_input == ContentInput.Radio
+            and input_type == InputType.Image
+            and ml_task == MLTask.ObjectDetection
+            and Tool.Rectangle in tools
+        ):
             training_loss = train_image_bounding_box(
-                api_key, assets, job, job_name, 
-                model_framework, model_name, model_repository, project_id)
+                api_key,
+                assets,
+                job,
+                job_name,
+                model_framework,
+                model_name,
+                model_repository,
+                project_id,
+            )
         else:
-            kili_print('not implemented yet')
-        training_losses.append([job_name, training_loss])   
+            kili_print("not implemented yet")
+        training_losses.append([job_name, training_loss])
     kili_print()
-    print(tabulate(training_losses, headers=['job_name', 'training_loss']))
+    print(tabulate(training_losses, headers=["job_name", "training_loss"]))
 
 
-
-    
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -22,8 +22,8 @@ class ModelFramework:
 @dataclass
 class ModelName:
     BertBaseMultilingualCased = 'bert-base-multilingual-cased'
+    DistilbertBaseCased = 'distilbert-base-cased'
     YoloV5 = 'ultralytics/yolov5'
-    
 
 @dataclass
 class ModelRepository:

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -10,27 +10,28 @@ def ensure_dir(file_path):
     return file_path
 
 
-def get_assets(kili, project_id):
+def get_assets(kili, project_id, label_types):
     total = kili.count_assets(project_id=project_id)
     first = 100
     assets = []
     for skip in tqdm(range(0, total, first)):
         assets += kili.assets(
-            project_id=project_id, 
-            first=first, 
-            skip=skip, 
+            project_id=project_id,
+            first=first,
+            skip=skip,
             disable_tqdm=True,
             fields=[
                 'id',
+                'externalId',
                 'content',
                 'labels.createdAt',
-                'labels.jsonResponse', 
+                'labels.jsonResponse',
                 'labels.labelType'])
     assets = [{
         **a,
         'labels': [
             l for l in sorted(a['labels'], key=lambda l: l['createdAt']) \
-                if l['labelType'] in ['DEFAULT', 'REVIEW']
+                if l['labelType'] in label_types
                 ][-1:],
                 } for a in assets]
     assets = [a for a in assets if len(a['labels']) > 0]

--- a/utils/huggingface/converters.py
+++ b/utils/huggingface/converters.py
@@ -1,0 +1,141 @@
+import json
+import os
+from typing import Dict, List
+
+from nltk import sent_tokenize
+from nltk.tokenize import TreebankWordTokenizer
+import requests
+from tqdm.auto import tqdm
+
+from utils.helpers import ensure_dir, kili_print
+
+
+def kili_assets_to_hf_ner_dataset(
+    api_key: str, job: Dict, job_name: str, path_dataset: str, assets: List[Dict]
+):
+
+    if os.path.exists(path_dataset):
+        os.remove(path_dataset)
+
+    job_categories = list(job["content"]["categories"].keys())
+    label_list = (
+        ["O"]
+        + ["B-" + jc for jc in job_categories]
+        + ["I-" + jc for jc in job_categories]
+    )
+
+    labels_to_ids = {label: i for i, label in enumerate(label_list)}
+
+    with open(ensure_dir(path_dataset), "w") as handler:
+        for asset in tqdm(assets):
+            response = requests.get(
+                asset["content"],
+                headers={
+                    "Authorization": f"X-API-Key: {api_key}",
+                },
+            )
+            text = response.text
+            annotations = asset["labels"][0]["jsonResponse"][job_name]["annotations"]
+            sentences = sent_tokenize(text)
+            offset = 0
+            for sentence_tokens in TreebankWordTokenizer().span_tokenize_sents(
+                sentences
+            ):
+                tokens = []
+                ner_tags = []
+                for start_without_offset, end_without_offset in sentence_tokens:
+                    start, end = (
+                        start_without_offset + offset,
+                        end_without_offset + offset,
+                    )
+                    token_annotations = [
+                        a
+                        for a in annotations
+                        if a["beginOffset"] <= start
+                        and a["beginOffset"] + len(a["content"]) >= end
+                    ]
+                    if len(token_annotations) > 0:
+                        category = token_annotations[0]["categories"][0]["name"]
+                        label = (
+                            "B-" + category
+                            if token_annotations[0]["beginOffset"] == start
+                            else "I-" + category
+                        )
+                    else:
+                        label = "O"
+                    tokens.append(text[start:end])
+                    ner_tags.append(labels_to_ids[label])
+                handler.write(
+                    json.dumps(
+                        {
+                            "tokens": tokens,
+                            "ner_tags": ner_tags,
+                        }
+                    )
+                    + "\n"
+                )
+                offset = offset + sentence_tokens[-1][1] + 1
+
+    return label_list
+
+
+def predicted_tokens_to_kili_annotations(
+    text: str,
+    predicted_label: List[str],
+    predicted_proba: List[float],
+    tokens: List[str],
+    null_category: str,
+    offset_in_text: int,
+):
+    """
+    Format token predictions into a the kili format.
+    :param: text:
+    """
+
+    kili_annotations = []
+    offset_in_sentence = 0
+    for label, proba, token in zip(predicted_label, predicted_proba, tokens):
+        if token in [
+            "[CLS]",
+            "[SEP]",
+        ]:  # special BERT tokens that should ignored at inference time
+            continue
+        if token.startswith(
+            "##"
+        ):  # number tokens annotation should be ignored when aligning categories
+            token = token.replace("##", "")
+
+        text_remaining = text[offset_in_sentence:]
+        ind = text_remaining.find(token)
+        if ind == -1:
+            raise Exception(f"token {token} not found in text {text_remaining}")
+
+        offset_in_sentence += ind
+
+        if label != null_category:
+            is_i_tag = label.startswith("I-")
+            c_kili = label.replace("B-", "").replace("I-", "")
+
+            ann = {
+                "beginOffset": offset_in_text + offset_in_sentence,
+                "content": token,
+                "endOffset": offset_in_text + offset_in_sentence + len(token),
+                "categories": [{"name": c_kili, "confidence": int(proba * 100)}],
+            }
+
+            if (
+                len(kili_annotations)
+                and ann["categories"][0]["name"]
+                == kili_annotations[-1]["categories"][0]["name"]
+                and (ann["beginOffset"] == kili_annotations[-1]["endOffset"] or is_i_tag)
+            ):
+                # merge with previous if same category and contiguous offset and onset:
+                kili_annotations[-1]["endOffset"] = ann["endOffset"]
+                kili_annotations[-1]["content"] += ann["content"]
+
+            else:
+                kili_annotations.append(ann)
+
+        offset_in_sentence += len(token)
+
+    return kili_annotations

--- a/utils/huggingface/predict.py
+++ b/utils/huggingface/predict.py
@@ -1,0 +1,111 @@
+from typing import Dict, List, Union
+import requests
+
+from nltk import sent_tokenize
+import numpy as np
+from transformers import AutoTokenizer
+from transformers import (
+    AutoModelForTokenClassification,
+    TFAutoModelForTokenClassification,
+)
+from utils.constants import ModelFramework
+from utils.huggingface.converters import predicted_tokens_to_kili_annotations
+
+
+def huggingface_predict_ner(
+    api_key: str,
+    assets: Union[List[Dict], List[str]],
+    model_framework: str,
+    model_path: str,
+    job_name: str,
+    verbose: int = 0,
+):
+
+    if model_framework == ModelFramework.PyTorch:
+        tokenizer = AutoTokenizer.from_pretrained(model_path, from_pt=True)
+        model = AutoModelForTokenClassification.from_pretrained(model_path)
+    elif model_framework == ModelFramework.Tensorflow:
+        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        model = TFAutoModelForTokenClassification.from_pretrained(model_path)
+    else:
+        raise NotImplementedError(
+            f"Predictions with model framework {model_framework} not implemented"
+        )
+
+    predictions = []
+
+    for asset in assets:
+        response = requests.get(
+            asset["content"],
+            headers={
+                "Authorization": f"X-API-Key: {api_key}",
+            },
+        )
+
+        offset = 0
+        predictions_asset = []
+
+        # sum_len_sentences = sum(len(sentence) for sentence in sent_tokenize(response.text))
+        # num_sentences = len(list(sent_tokenize(response.text)))
+        # len_text = len(response.text)
+        # print(f"sum sentences:{sum_len_sentences}")
+        # print(f"len_text:{len_text}")
+        # print(f"num_sentences:{num_sentences}")
+        # return 0
+        text = response.text
+        for sentence in sent_tokenize(text):
+            offset_inc = text[offset:].find(sentence)
+            if offset_inc == -1:
+                raise Exception(f"Sentence {sentence} not found in text!")
+            offset += offset_inc
+
+            predictions_sentence = compute_sentence_predictions(
+                model_framework, tokenizer, model, sentence, offset
+            )
+
+            predictions_asset.extend(predictions_sentence)
+
+        predictions.append({job_name: {"annotations": predictions_asset}})
+
+        if verbose:
+            print(sentence)
+            for p in predictions_asset:
+                print(p)
+
+    return predictions
+
+
+def compute_sentence_predictions(model_framework, tokenizer, model, sentence, offset):
+    sequence = sentence[: model.config.max_position_embeddings]  # imposed by the model
+
+    if model_framework == ModelFramework.PyTorch:
+        tokens = tokenizer(
+            sequence,
+            return_tensors="pt",
+            max_length=model.config.max_position_embeddings,
+        )
+    else:
+        tokens = tokenizer(
+            sequence,
+            return_tensors="tf",
+            max_length=model.config.max_position_embeddings,
+        )
+
+    output = model(**tokens)
+
+    logits = np.squeeze(output["logits"].detach().numpy())
+    probas_all = np.exp(logits) / np.expand_dims(np.sum(np.exp(logits), axis=1), axis=1)
+    predicted_ids = np.argmax(probas_all, axis=-1).tolist()
+    probas = [probas_all[i, p] for i, p in enumerate(predicted_ids)]
+    predicted_labels = [model.config.id2label[p] for p in predicted_ids]
+
+    predictions_sentence = predicted_tokens_to_kili_annotations(
+        sequence,
+        predicted_labels,
+        probas,
+        [tokenizer.batch_decode([t])[0] for t in tokens["input_ids"][0]],
+        model.config.id2label[0],
+        offset,
+    )  # by convention we consider that the null category is the first one in the label list, hence model.config.id2label[0]
+
+    return predictions_sentence


### PR DESCRIPTION
**Overview**
This PR adds the capability to run the predictions from a model obtained from a NER training.

It works as follows:
* it finds the latest trained model for the NER job of a given Kili project. It can also load the model from a path given as an argument.
* the `--dry-run` prevents the predictions to be written into the Kili project.
* the `--verbose` arguments tells if the predictions should be printed to the standard output.
* behind the scenes, it splits the asset's text into sentences, applies the same tokenization as the trained model, outputs the predictions per sentence, reshape the outputs into the Kili format by realigning the predictions.

Also added a couple of changes to `train.py`:  storing the labels in the model config, and also specifying the label types on which to train the model.

**Testing**
No unit test written yet. Tested on a Kili project:
<img width="1217" alt="image" src="https://user-images.githubusercontent.com/1255753/156210360-bd351c18-8c1b-48f6-a989-132af64e3791.png">
It is "functionning" but no indication of performance for now.
