### PR TITLE
ML-31: automl for object detection using Yolov5

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "python.formatting.provider": "black"
+  "python.formatting.provider": "black",
+  "python.linting.mypyEnabled": true,
+  "python.linting.enabled": true
 }

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ AutoML is a lightweight library to create ML models in a data-centric AI way:
 1. Label on [Kili](https://www.kili-technology.com)
 2. **Train** a model with AutoML and evaluate its performance in one line of code
 3. **Push** predictions to [Kili](https://www.kili-technology.com) to accelerate the labeling in one line of code
-4. **Prioritize** labeling on [Kili](https://www.kili-technology.com) to label the data the will improve your model the most first
+4. **Prioritize** labeling on [Kili](https://www.kili-technology.com) to label the data that will improve your model the most first
 
 Iterate.
 
-Once you are satisfied with the performance, in one line of code, **serve** the model and monitor the performance keeping human in the loop with [Kili](https://www.kili-technology.com).
+Once you are satisfied with the performance, in one line of code, **serve** the model and monitor the performance keeping a human in the loop with [Kili](https://www.kili-technology.com).
 
 ## Installation
 
@@ -19,24 +19,14 @@ cd automl
 git submodule update --init
 ```
 
-If you are using `pip`:
+then
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt -r utils/ultralytics/yolov5/requirements.txt
 ```
-if you are using `conda`:
-```bash
-conda install --file requirements.txt
-```
-
-then install the submodule requirements:
-```bash
-pip install -r utils/ultralytics/yolov5/requirements.txt
-```
-
 
 ## Usage
 
-AutoML is made to be very simple to use. The main methods are:
+We made AutoML very simple to use. The main methods are:
 
 ### Train a model
 
@@ -48,9 +38,9 @@ python train.py \
 
 Retrieve the annotated data from the project and specialize the best model among the following ones on each task:
 
-- Hugging Face (text classification and NER)
+- Hugging Face (NER)
+- YOLOv5 (Object Detection)
 - spaCy (coming soon)
-- YOLOv5 (coming soon)
 - Simple Transformers (coming soon)
 - Catalyst (coming soon)
 - XGBoost & LightGBM (coming soon)
@@ -59,7 +49,7 @@ Compute model loss to infer when you can stop labeling.
 
 ![Train a model](./images/train.png)
 
-### Push predictions to Kili (coming soon)
+### Push predictions to Kili
 
 ```bash
 python predict.py \
@@ -101,12 +91,12 @@ python serve.py \
     --project-id $KILI_PROJECT_ID
 ```
 
-Serve trained models while pushing assets and predictions to [Kili](https://www.kili-technology.com) for continuous labeling. Allows to monitor the model drift.
+Serve trained models while pushing assets and predictions to [Kili](https://www.kili-technology.com) for continuous labeling. Allows monitoring the model drift.
 
 ![Serve a model](./images/serve.png)
 
 ## Disclaimer
 
-AutoML is a utility library that trains and serves models. It is your responsibility to determine whether the performance of the model make it usable or not.
+AutoML is a utility library that trains and serves models. It is your responsibility to determine whether the model performance is high enough or not.
 
 Don't hesitate to contribute!

--- a/predict.py
+++ b/predict.py
@@ -1,20 +1,23 @@
-from glob import glob
 import os
 from typing import Optional, List, Dict
-from xmlrpc.client import boolean
 
 import click
 from kili.client import Kili
 
 from utils.constants import (
     ContentInput,
-    HOME,
     InputType,
     MLTask,
     ModelFramework,
     ModelRepository,
+    Tool,
 )
-from utils.helpers import get_assets, get_project, kili_print
+from utils.helpers import (
+    get_assets,
+    get_project,
+    kili_print,
+    get_last_trained_model_path,
+)
 
 
 def predict_ner(
@@ -25,23 +28,8 @@ def predict_ner(
     model_path: Optional[str],
     verbose: int,
 ):
-    if model_path is None:
-        path_project_models = os.path.join(
-            HOME, project_id, job_name, "*", "model", "*", "*"
-        )
-        paths_project_sorted = sorted(glob(path_project_models), reverse=True)
-        model_path = None
-        while len(paths_project_sorted):
-            path_model_candidate = paths_project_sorted.pop(0)
-            if len(os.listdir(path_model_candidate)) > 0 and os.path.exists(
-                os.path.join(path_model_candidate, "pytorch_model.bin")
-            ):
-                model_path = path_model_candidate
-                kili_print(f"Trained model found in path: {model_path}")
-                break
-        if model_path is None:
-            raise Exception("No trained model found for job {job}. Exiting ...")
-    split_path = os.path.normpath(model_path).split(os.path.sep)
+    model_path_res = get_last_trained_model_path(job_name, project_id, model_path, ["*", "model", "*", "*"], "pytorch_model.bin")
+    split_path = os.path.normpath(model_path_res).split(os.path.sep)
     if split_path[-4] == ModelRepository.HuggingFace:
         model_repository = ModelRepository.HuggingFace
         kili_print(f"Model base repository: {model_repository}")
@@ -56,8 +44,34 @@ def predict_ner(
         from utils.huggingface.predict import huggingface_predict_ner
 
         return huggingface_predict_ner(
-            api_key, assets, model_framework, model_path, job_name, verbose=verbose
+            api_key, assets, model_framework, model_path_res, job_name, verbose=verbose
         )
+
+
+def predict_object_detection(
+    api_key: str,
+    assets: List[Dict],
+    job_name: str,
+    project_id: str,
+    model_path: Optional[str],
+    verbose: int,
+):
+    from utils.ultralytics.predict import ultralytics_predict_object_detection
+
+    model_path_res = get_last_trained_model_path(job_name, project_id, model_path, ["*", "model", "*", "*", "exp", "weights"], "best.pt")
+    split_path = os.path.normpath(model_path_res).split(os.path.sep)
+    if split_path[-6] == ModelRepository.Ultralytics:
+        model_repository = ModelRepository.Ultralytics
+        kili_print(f"Model base repository: {model_repository}")
+    else:
+        raise ValueError(f"Unknown model base repository: {model_repository}")
+    if split_path[-4] in [ModelFramework.PyTorch, ModelFramework.Tensorflow]:
+        model_framework = split_path[-4]
+        kili_print(f"Model framework: {model_framework}")
+    else:
+        raise ValueError(f"Unknown model framework: {model_framework}")
+    if model_repository == ModelRepository.Ultralytics:
+        return ultralytics_predict_object_detection(api_key, assets, project_id, model_framework, model_path_res, job_name, verbose)
 
 
 @click.command()
@@ -84,6 +98,12 @@ def predict_ner(
     default=0,
     help="Verbose level",
 )
+@click.option(
+    "--max-assets",
+    default=None,
+    type=int,
+    help="Maximum number of assets to consider",
+)
 def main(
     api_key: str,
     project_id: str,
@@ -91,15 +111,17 @@ def main(
     dry_run: bool,
     from_model: Optional[str],
     verbose: bool,
+    max_assets: Optional[int]
 ):
 
     kili = Kili(api_key=api_key)
     input_type, jobs = get_project(kili, project_id)
-    assets = get_assets(kili, project_id, label_types.split(","))
+    assets = get_assets(kili, project_id, label_types.split(","), max_assets = max_assets)
 
     for job_name, job in jobs.items():
         content_input = job.get("content", {}).get("input")
         ml_task = job.get("mlTask")
+        tools = job.get("tools")
 
         if (
             content_input == ContentInput.Radio
@@ -117,8 +139,28 @@ def main(
                     json_response_array=json_responses,
                     model_name_array=["Kili AutoML"] * len(assets),
                 )
+
+        elif (
+            content_input == ContentInput.Radio
+            and input_type == InputType.Image
+            and ml_task == MLTask.ObjectDetection
+            and Tool.Rectangle in tools
+        ):
+            id_json_list = predict_object_detection(
+                api_key, assets, job_name, project_id, from_model, verbose
+            )
+
+            if not dry_run:
+                kili.create_predictions(
+                    project_id,
+                    external_id_array=[a[0] for a in id_json_list],
+                    json_response_array=[a[1] for a in id_json_list],
+                    model_name_array=["Kili AutoML"] * len(id_json_list),
+                )
+
         else:
             kili_print("not implemented yet")
+
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 click
 datasets
 kili
+jinja2
 nltk>=3.3
 numpy
 requests

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,18 +1,30 @@
 import os
+from typing import List, Optional, Dict, Tuple
+from glob import glob
+from numpy import void
 
 from termcolor import colored
 from tqdm import tqdm
 
-def ensure_dir(file_path):
+from utils.constants import HOME
+
+
+def categories_from_job(job: Dict):
+    return list(job["content"]["categories"].keys())
+
+
+def ensure_dir(file_path: str):
     directory = os.path.dirname(file_path)
     if not os.path.exists(directory):
         os.makedirs(directory)
     return file_path
 
 
-def get_assets(kili, project_id, label_types):
+def get_assets(kili, project_id: str, label_types: List[str], max_assets: Optional[int] = None) -> List[Dict]:
     total = kili.count_assets(project_id=project_id)
-    first = 100
+    total = total if max_assets is None else min(total, max_assets)
+
+    first = min(100, total)
     assets = []
     for skip in tqdm(range(0, total, first)):
         assets += kili.assets(
@@ -21,38 +33,88 @@ def get_assets(kili, project_id, label_types):
             skip=skip,
             disable_tqdm=True,
             fields=[
-                'id',
-                'externalId',
-                'content',
-                'labels.createdAt',
-                'labels.jsonResponse',
-                'labels.labelType'])
-    assets = [{
-        **a,
-        'labels': [
-            l for l in sorted(a['labels'], key=lambda l: l['createdAt']) \
-                if l['labelType'] in label_types
-                ][-1:],
-                } for a in assets]
-    assets = [a for a in assets if len(a['labels']) > 0]
+                "id",
+                "externalId",
+                "content",
+                "labels.createdAt",
+                "labels.jsonResponse",
+                "labels.labelType",
+            ],
+        )
+    assets = [
+        {
+            **a,
+            "labels": [
+                l
+                for l in sorted(a["labels"], key=lambda l: l["createdAt"])
+                if l["labelType"] in label_types
+            ][-1:],
+        }
+        for a in assets
+    ]
+    assets = [a for a in assets if len(a["labels"]) > 0]
     return assets
 
 
-def get_project(kili, project_id):
-    projects = kili.projects(project_id=project_id, fields=['inputType', 'jsonInterface'])
+def get_project(kili, project_id: str) -> Tuple[str, Dict]:
+    projects = kili.projects(
+        project_id=project_id, fields=["inputType", "jsonInterface"]
+    )
     if len(projects) == 0:
-        raise ValueError('no such project')
-    input_type = projects[0]['inputType']
-    jobs = projects[0]['jsonInterface'].get('jobs', {})
+        raise ValueError("no such project")
+    input_type = projects[0]["inputType"]
+    jobs = projects[0]["jsonInterface"].get("jobs", {})
     return input_type, jobs
 
 
-def kili_print(*args, **kwargs):
-    print(colored('kili:', 'yellow', attrs=['bold']), *args, **kwargs)
+def kili_print(*args, **kwargs) -> void:
+    print(colored("kili:", "yellow", attrs=["bold"]), *args, **kwargs)
 
 
-def set_default(x, x_default, x_name, x_range):
+def build_model_repository_path(
+    root_dir: str, project_id: str, job_name: str, model_repository: str
+) -> str:
+    return os.path.join(root_dir, project_id, job_name, model_repository)
+
+
+def build_dataset_path(
+    root_dir: str, project_id: str, job_name: str
+) -> str:
+    return os.path.join(root_dir, project_id, job_name, "dataset")
+
+
+def build_inference_path(
+    root_dir: str, project_id: str, job_name: str, model_repository: str
+) -> str:
+    return os.path.join(root_dir, project_id, job_name, model_repository, "inference")
+
+
+def parse_label_types(label_types: Optional[str]) -> List[str]:
+    return label_types.split(",") if label_types else ["DEFAULT", "REVIEW"]
+
+
+def set_default(x: str, x_default: str, x_name: str, x_range: List[str]) -> str:
     if x not in x_range:
-            kili_print(f'defaulting to {x_name}={x_default}')
-            x = x_default
+        kili_print(f"defaulting to {x_name}={x_default}")
+        x = x_default
     return x
+
+
+def get_last_trained_model_path(job_name: str, project_id: str, model_path: str, project_path_wildcard: List[str], weights_filename: str) -> str:
+    if model_path is None:
+        path_project_models = os.path.join(
+            HOME, project_id, job_name, *project_path_wildcard
+        )
+        paths_project_sorted = sorted(glob(path_project_models), reverse=True)
+        model_path = None
+        while len(paths_project_sorted):
+            path_model_candidate = paths_project_sorted.pop(0)
+            if len(os.listdir(path_model_candidate)) > 0 and os.path.exists(
+                os.path.join(path_model_candidate, weights_filename)
+            ):
+                model_path = path_model_candidate
+                kili_print(f"Trained model found in path: {model_path}")
+                break
+        if model_path is None:
+            raise Exception("No trained model found for job {job}. Exiting ...")
+    return model_path

--- a/utils/huggingface/train.py
+++ b/utils/huggingface/train.py
@@ -12,7 +12,7 @@ from transformers import AutoModelForSequenceClassification, AutoModelForTokenCl
     Trainer, TrainingArguments
 
 from utils.constants import ModelFramework
-from utils.helpers import ensure_dir, kili_print
+from utils.helpers import ensure_dir, kili_print, categories_from_job
 from utils.huggingface.converters import kili_assets_to_hf_ner_dataset
 
 
@@ -104,7 +104,7 @@ def huggingface_train_text_classification_single(
     kili_print(f'Downloading data to {path_dataset}')
     if os.path.exists(path_dataset):
         os.remove(path_dataset)
-    job_categories = list(job['content']['categories'].keys())
+    job_categories = categories_from_job(job)
     with open(ensure_dir(path_dataset), 'w') as handler:
         for asset in assets:
             response = requests.get(asset['content'], headers={

--- a/utils/ultralytics/kili_template.yml
+++ b/utils/ultralytics/kili_template.yml
@@ -1,0 +1,121 @@
+# YOLOv5 🚀 by Ultralytics, GPL-3.0 license
+# Kili project dataset https://cloud.kili-technology.com/label/projects/ckysuic0y0ldc0lvoeltld164/menu/analytics
+# Before running, make sure that the KILI_API_KEY environment variable is set with the API key obtained from Kili
+# (in https://cloud.kili-technology.com/label/my-account/api-key if you are using the cloud version)
+#
+# Example usage: python train.py --data kili.yaml
+# parent
+# ├── yolov5
+# └── datasets
+#     └── kili  ← downloads here
+#
+
+# Train/val/test sets as 1) dir: path/to/imgs, 2) file: path/to/imgs.txt, or 3) list: [path/to/imgs1, path/to/imgs2, ..]
+path: {{ data_path }} # ../datasets/kili/<YOUR_KILI_PROJECT_ID> # dataset root dir with your Kili project ID
+train: images/train # train images (relative to 'path')
+val: images/val # val images (relative to 'path')
+test: images/test # test images (optional)
+
+# Classes
+names: [{% for class_name in class_names %}"{{ class_name }}", {% endfor %}] # class names, must match your Kili project class names.
+nc: {{ number_classes }} # number of classes (cardinality of the list above)
+
+# The proportions of he training and validation dataset, the sum should be < 1.0. The remainder is used as the test set.
+train_val_proportions:
+  - 0.8
+  - 0.1
+
+# Download script/URL (optional)
+download: |
+  import math
+  import os
+  import re
+  import time
+  from kili.client import Kili
+  import requests
+  from tqdm.auto import tqdm
+  print("Downloading datasets from Kili")
+  train_val_proportions = yaml['train_val_proportions']
+  path = yaml.get('path', '')
+  if '/kili/' not in path:
+      raise ValueError("'path' field in config must contain '/kili/'")
+  project_id = "{{ project_id }}"
+  kili = Kili(api_key="{{ kili_api_key }}")
+  total ={% if max_assets is not none %} min({{ max_assets }}, kili.count_assets(project_id=project_id)) {% else %} kili.count_assets(project_id=project_id) {% endif %}
+  if total == 0:
+      raise Exception("No asset in project. Exiting...")
+  first = 100
+  assets = []
+  for skip in tqdm(range(0, total, first)):
+      assets += kili.assets(
+          project_id=project_id,
+          first=first,
+          skip=skip,
+          disable_tqdm=True,
+          fields=[
+              'id',
+              'content',
+              'labels.createdAt',
+              'labels.jsonResponse',
+              'labels.labelType'])
+  assets = [{
+          **a,
+          'labels': [
+              l for l in sorted(a['labels'], key=lambda l: l['createdAt']) \
+                  if l['labelType'] in [{% for label_type in label_types %}"{{ label_type }}", {% endfor %}]
+          ][-1:],
+      } for a in assets]
+  assets = [a for a in assets if len(a['labels']) > 0]
+  n_train_assets = math.floor(len(assets) * train_val_proportions[0])
+  n_val_assets = math.floor(len(assets) * train_val_proportions[1])
+  assets_splits = {
+      "train": assets[:n_train_assets],
+      "val": assets[n_train_assets : n_train_assets + n_val_assets],
+      "test": assets[n_train_assets + n_val_assets :],
+  }
+
+  for name_split, assets_split in assets_splits.items():
+      if len(assets_split) == 0:
+          raise Exception("No asset in dataset, exiting...")
+      path_split = os.path.join(path, yaml.get(name_split, ''))
+      print(f"Building {name_split} in {path_split} ...")
+      os.makedirs(path_split, exist_ok=True)
+      for asset in tqdm(assets_split):
+          tic = time.time()
+          img_data = requests.get(asset['content'], headers={
+                  'Authorization': 'X-API-Key: {{ kili_api_key }}',
+              }).content
+          with open(os.path.join(path_split, asset['id'] + '.jpg'), 'wb') as handler:
+              handler.write(img_data)
+          toc = time.time() - tic
+          throttling_per_call = 60.0 / 250 # Kili API calls are limited to 250 per minute
+          if toc < throttling_per_call:
+              time.sleep(throttling_per_call - toc)
+
+      names = yaml.get('names', [])
+      path_labels = re.sub('/images/', '/labels/', path_split)
+      print(path_labels)
+      os.makedirs(path_labels, exist_ok=True)
+      for asset in assets_split:
+          with open(os.path.join(path_labels, asset['id'] + '.txt'), 'w') as handler:
+              json_response = asset['labels'][0]['jsonResponse']
+              for job in json_response.values():
+                  for annotation in job.get('annotations', []):
+                      name = annotation['categories'][0]['name']
+                      try:
+                          category = names.index(name)
+                      except ValueError:
+                          pass
+                      bounding_poly = annotation.get('boundingPoly', [])
+                      if len(bounding_poly) < 1:
+                          continue
+                      if 'normalizedVertices' not in bounding_poly[0]:
+                          continue
+                      normalized_vertices = bounding_poly[0]['normalizedVertices']
+                      x_s = [vertice['x'] for vertice in normalized_vertices]
+                      y_s = [vertice['y'] for vertice in normalized_vertices]
+                      x_min, y_min = min(x_s), min(y_s)
+                      x_max, y_max = max(x_s), max(y_s)
+                      _x_, _y_ = (x_max + x_min) / 2, (y_max + y_min) / 2
+                      _w_, _h_ = x_max - x_min, y_max - y_min
+                      handler.write(f'{category} {_x_} {_y_} {_w_} {_h_}\n')

--- a/utils/ultralytics/predict.py
+++ b/utils/ultralytics/predict.py
@@ -1,0 +1,126 @@
+import os
+from typing import Union, List, Dict, Tuple
+from io import BytesIO
+import shutil
+from glob import glob
+
+from PIL import Image
+import requests
+from tqdm.auto import tqdm
+import yaml
+
+from utils.helpers import kili_print, build_inference_path
+from utils.constants import HOME, ModelFramework, ModelRepository
+
+
+def ultralytics_predict_object_detection(
+    api_key: str,
+    assets: Union[List[Dict], List[str]],
+    project_id: str,
+    model_framework: str,
+    model_path: str,
+    job_name: str,
+    verbose: int = 0,
+) -> List[Tuple[str, Dict]]:
+
+    if model_framework == ModelFramework.PyTorch:
+        filename_weights = "best.pt"
+    else:
+        raise NotImplementedError(
+            f"Predictions with model framework {model_framework} not implemented"
+        )
+
+    kili_print(f"Loading model {model_path}")
+    kili_print(f"for job {job_name}")
+    with open(os.path.join(model_path, "..", "..", "kili.yaml")) as f:
+        kili_data_dict = yaml.load(f, Loader=yaml.FullLoader)
+
+    inference_path = build_inference_path(
+        HOME, project_id, job_name, ModelRepository.Ultralytics
+    )
+    model_weights = os.path.join(model_path, filename_weights)
+
+    # path needs to be cleaned-up to avoid inferring unnecessary items.
+    if os.path.exists(inference_path) and os.path.isdir(inference_path):
+        shutil.rmtree(inference_path)
+    os.makedirs(inference_path)
+
+    kili_print("Downloading project images...")
+    filenames = []
+    for asset in tqdm(assets):
+        img_data = requests.get(
+            asset["content"],
+            headers={
+                "Authorization": f"X-API-Key: {api_key}",
+            },
+        ).content
+
+        d = Image.open(BytesIO(img_data))
+        fmt = d.format
+        filename = os.path.join(inference_path, asset["id"] + "." + fmt.lower())
+
+        with open(filename, "w") as fp:
+            d.save(fp, fmt)
+
+        filenames.append((asset["id"], asset["externalId"], filename))
+
+    kili_print("Starting Ultralytics' YoloV5 inference...")
+    cmd = (
+        f'python detect.py '
+        + f'--weights "{model_weights}" '
+        + f'--save-txt --save-conf --nosave --exist-ok '
+        + f'--source "{inference_path}" --project "{inference_path}"'
+    )
+    os.system("cd utils/ultralytics/yolov5 && " + cmd)
+
+    inference_files = glob(os.path.join(inference_path, "exp", "labels", "*.txt"))
+    inference_files_by_id = {
+        get_id_from_path(pf, fmt.lower()): pf for pf in inference_files
+    }
+
+    predictions = []
+    for filename in filenames:
+        if filename[0] in inference_files_by_id:
+            kili_predictions = yolov5_to_kili_json(
+                inference_files_by_id[filename[0]], kili_data_dict["names"]
+            )
+            if verbose >= 1:
+                print(f"Asset {filename[1]}: {kili_predictions}")
+            predictions.append(
+                (filename[1], {job_name: {"annotations": kili_predictions}})
+            )
+    return predictions
+
+
+def get_id_from_path(path_yolov5_inference: str, fmt: str) -> str:
+    return os.path.split(path_yolov5_inference)[-1].split(".")[0]
+
+
+def yolov5_to_kili_json(path_yolov5_inference: str, ind_to_categories: List[str]) -> Dict:
+
+    annotations = []
+    with open(path_yolov5_inference, "r") as f:
+        for l in f.readlines():
+            c, x, y, w, h, p = l.split(" ")
+            x, y, w, h = float(x), float(y), float(w), float(h)
+            c = int(c)
+            p = int(100.0 * float(p))
+
+            annotations.append(
+                {
+                    "boundingPoly": [
+                        {
+                            "normalizedVertices": [
+                                {"x": x - w / 2, "y": y + h / 2},
+                                {"x": x - w / 2, "y": y - h / 2},
+                                {"x": x + w / 2, "y": y - h / 2},
+                                {"x": x + w / 2, "y": y + h / 2},
+                            ]
+                        }
+                    ],
+                    "categories": [{"name": ind_to_categories[c], "confidence": p}],
+                    "type": "rectangle",
+                }
+            )
+
+    return annotations

--- a/utils/ultralytics/train.py
+++ b/utils/ultralytics/train.py
@@ -1,62 +1,57 @@
-from datetime import datetime
-import json
 import os
 from pyexpat import features
+from typing import Dict, List, Optional
+from datetime import datetime
 import shutil
-from typing import Dict, List
 
-import requests
-import torch
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import pandas as pd
 
-from utils.constants import ModelFramework
-from utils.helpers import ensure_dir, kili_print
-from utils.ultralytics.yolov5.train import run
+from utils.helpers import categories_from_job, kili_print
 
+env = Environment(
+    loader=FileSystemLoader(os.path.abspath("utils/ultralytics")), autoescape=select_autoescape()
+)
 
 
 def ultralytics_train_yolov5(
-        api_key:str, assets:List[Dict], job: Dict, job_name:str,
-        model_framework:str, model_name:str, path:str) -> float:
-    '''
-    Source: https://huggingface.co/docs/transformers/training
-    '''
-    kili_print(job_name)
-    path_dataset = os.path.join(path, 'dataset')
-    if os.path.exists(path_dataset):
-        shutil.rmtree(path_dataset)
-    path_images = os.path.join(path_dataset, 'images', 'train')
-    kili_print(f'Downloading data to {path_dataset}')
-    if os.path.exists(path_images):
-        os.remove(path_images)
-    job_categories = list(job['content']['categories'].keys())
-    for asset in assets:
-        img_data = requests.get(asset['content'], headers={
-                'Authorization': f'X-API-Key: {api_key}',
-            }).content
-        with open(ensure_dir(os.path.join(path_images, asset['id'] + '.jpg')), 'wb') as handler:
-            handler.write(img_data)
-    path_labels = os.path.join(path_dataset, 'labels', 'train')
-    os.makedirs(path_labels, exist_ok=True)
-    for asset in assets:
-        with open(ensure_dir(os.path.join(path_labels, asset['id'] + '.txt')), 'w') as handler:
-            json_response = asset['labels'][0]['jsonResponse']
-            for job in json_response.values():
-                for annotation in job.get('annotations', []):
-                    name = annotation['categories'][0]['name']
-                    category = job_categories.index(name)
-                    bounding_poly = annotation.get('boundingPoly', [])
-                    if len(bounding_poly) < 1:
-                        continue
-                    if 'normalizedVertices' not in bounding_poly[0]:
-                        continue
-                    normalized_vertices = bounding_poly[0]['normalizedVertices']
-                    x_s = [vertice['x'] for vertice in normalized_vertices]
-                    y_s = [vertice['y'] for vertice in normalized_vertices]
-                    x_min, y_min = min(x_s), min(y_s)
-                    x_max, y_max = max(x_s), max(y_s)
-                    _x_, _y_ = (x_max + x_min) / 2, (y_max + y_min) / 2
-                    _w_, _h_ = x_max - x_min, y_max - y_min
-                    handler.write(f'{category} {_x_} {_y_} {_w_} {_h_}\n')
-    # TODO: write kili.yaml
-    run(data='kili.yaml')
-    
+    api_key: str,
+    path: str,
+    job: Dict,
+    max_assets: Optional[int],
+    json_args: Dict,
+    project_id: str,
+    model_framework: str,
+    label_types: List[str]
+) -> float:
+    yolov5_path = "utils/ultralytics/yolov5"
+
+    template = env.get_template("kili_template.yml")
+    class_names = categories_from_job(job)
+    data_path = os.path.join(path, "data")
+    config_data_path = os.path.join(yolov5_path, "data", "kili.yaml")
+    output_path = os.path.join(path, 'model', model_framework,
+        datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+    os.makedirs(output_path)
+
+    with open(config_data_path, "w") as f:
+        f.write(
+            template.render(
+                data_path=data_path,
+                class_names=class_names,
+                number_classes=len(class_names),
+                kili_api_key=api_key,
+                project_id=project_id,
+                label_types=label_types,
+                max_assets=max_assets
+            )
+        )
+
+    args_from_json = " ".join(f" --{k} {v}" for k, v in json_args.items())
+    kili_print("Starting Ultralytics\' YoloV5 ...")
+    os.system(f'cd {yolov5_path} && python train.py --data kili.yaml --project "{output_path}" {args_from_json}')
+    shutil.copy(config_data_path, output_path)
+    df_result = pd.read_csv(os.path.join(output_path, "exp", "results.csv"))
+
+    # we take the class loss as the main metric
+    return df_result.iloc[-1:][['        val/obj_loss']].to_numpy()[0][0]


### PR DESCRIPTION
** Overview **
This PR adds the capability of training and predicting an object detection model from a Kili dataset using the YoloV5 model. 

** Code changes **
* Adds the ultralytics yolov5 training using a `data.yaml` YoloV5 template filled with `jinja2`. The `data.yaml` contains the classes definition and the code to download the assets into a folder Yolov5 can read. The "object" loss is returned as the job loss.
* Adds the prediction step by downloading the assets, picking the last model available in the job cache folder, and finally calling YoloV5 `detect` from the command line. The predictions are stored in a folder of the job cache directory, then read and shaped in the Kili format. Finally, they are uploaded.
* Some refactoring to put several methods in common across jobs.
* Readme update.

** Tests **
Tested on the Plastic In River challenge. It correctly trains a model that detects plastic waste. No unit/e2e tests (yet).