### PR TITLE
Fix/quick fix api key

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -75,7 +75,7 @@ def predict_object_detection(
 
 
 @click.command()
-@click.option("--api-key", default=os.environ["KILI_API_KEY"], help="Kili API Key")
+@click.option("--api-key", default=os.environ.get("KILI_API_KEY"), help="Kili API Key")
 @click.option("--project-id", required=True, help="Kili project ID")
 @click.option(
     "--label-types",

--- a/train.py
+++ b/train.py
@@ -157,7 +157,7 @@ def train_text_classification_single(
 
 
 @click.command()
-@click.option("--api-key", default=os.environ["KILI_API_KEY"], help="Kili API Key")
+@click.option("--api-key", default=os.environ.get("KILI_API_KEY"), help="Kili API Key")
 @click.option(
     "--model-framework", default=None, help="Model framework (eg. pytorch, tensorflow)"
 )


### PR DESCRIPTION
Quick fix that makes the `--api-key` argument call works in train and predict when the `KILI_API_KEY` env variable is not set.