### PR TITLE
Fix/import typing literal python 3 7

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -3,7 +3,11 @@ import random
 from io import BytesIO
 import json
 import shutil
-from typing import Any, List, Literal, Optional, Dict, Tuple
+from typing import Any, List, Optional, Dict, Tuple
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 from dataclasses import dataclass
 
 import torch

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -4,9 +4,12 @@ from io import BytesIO
 import json
 import shutil
 from typing import Any, List, Optional, Dict, Tuple
-try:
+
+import sys
+
+if sys.version_info >= (3, 8):
     from typing import Literal
-except ImportError:
+else:
     from typing_extensions import Literal
 from dataclasses import dataclass
 


### PR DESCRIPTION
Little bug correction to import Literal from typing_extensions in Python version older than 3.8 (including colab)