### PR TITLE
Fix/import typing literal python 3 7

### DIFF
--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -3,7 +3,8 @@ import random
 from io import BytesIO
 import json
 import shutil
-from typing import Any, List, Literal, Optional, Dict, Tuple
+from typing import Any, List, Optional, Dict, Tuple
+from typing_extensions import Literal
 from dataclasses import dataclass
 
 import torch


### PR DESCRIPTION
Import modification for compatibility with Python < 3.8 (including Colab)