### PR TITLE
import update for compatibility with Python < 3.8

### DIFF
--- a/kiliautoml/models/_hugging_face_named_entity_recognition_model.py
+++ b/kiliautoml/models/_hugging_face_named_entity_recognition_model.py
@@ -1,4 +1,5 @@
-from typing import Union, List, Dict, TypedDict, Any, Optional
+from typing import Union, List, Dict, Any, Optional
+from typing_extensions import TypedDict
 import os
 from warnings import warn
 from datetime import datetime


### PR DESCRIPTION
Same issue as last time to import TypedDict from typing with Python < 3.8
With the fix it works with Python < 3.7, I hoped it does not broke Python >= 3.8...