### PR TITLE
feat(ML-219): AADS, on Automl, when I use train on text tasks, I see it logged on wandb

### DIFF
--- a/kiliautoml/mixins/_hugging_face_mixin.py
+++ b/kiliautoml/mixins/_hugging_face_mixin.py
@@ -2,6 +2,7 @@
 from abc import ABCMeta
 import os
 from typing import List
+from datetime import datetime
 
 from transformers import (
     AutoModelForSequenceClassification,
@@ -9,6 +10,7 @@ from transformers import (
     AutoTokenizer,
     TFAutoModelForSequenceClassification,
     TFAutoModelForTokenClassification,
+    TrainingArguments,
 )
 
 from kiliautoml.utils.constants import (
@@ -97,3 +99,13 @@ class HuggingFaceMixin(metaclass=ABCMeta):
         else:
             raise ValueError("Unknown model framework")
         return model_path_res, cls.model_repository, model_framework
+
+    @staticmethod
+    def _get_training_args(path_model, model_name):
+        date = datetime.now().strftime("%Y-%m-%d_%H:%M")
+        training_args = TrainingArguments(
+            os.path.join(path_model, "training_args"),  # type:ignore
+            report_to="wandb",  # type:ignore
+            run_name=model_name + "_" + date,
+        )
+        return training_args

--- a/kiliautoml/models/_hugging_face_named_entity_recognition_model.py
+++ b/kiliautoml/models/_hugging_face_named_entity_recognition_model.py
@@ -11,7 +11,6 @@ import datasets
 from transformers import (
     DataCollatorForTokenClassification,
     Trainer,
-    TrainingArguments,
 )
 from tqdm.auto import tqdm
 
@@ -221,7 +220,7 @@ class HuggingFaceNamedEntityRecognitionModel(BaseModel, HuggingFaceMixin, KiliTe
         train_dataset = tokenized_datasets["train"]  # type:  ignore
         path_model = Path.append_hf_model_folder(path, self.model_framework)
 
-        training_args = TrainingArguments(os.path.join(path_model, "training_args"))
+        training_args = self._get_training_args(path_model, model_name)
         data_collator = DataCollatorForTokenClassification(tokenizer)
         trainer = Trainer(
             model=model,

--- a/kiliautoml/models/_hugging_face_text_classification_model.py
+++ b/kiliautoml/models/_hugging_face_text_classification_model.py
@@ -8,7 +8,6 @@ import datasets
 
 from transformers import (
     Trainer,
-    TrainingArguments,
 )
 import numpy as np
 
@@ -164,7 +163,7 @@ class HuggingFaceTextClassificationModel(BaseModel, HuggingFaceMixin, KiliTextPr
 
         path_model = Path.append_hf_model_folder(path, self.model_framework)
 
-        training_args = TrainingArguments(os.path.join(path_model, "training_args"))
+        training_args = self._get_training_args(path_model, model_name)
         trainer = Trainer(
             model=model,
             args=training_args,

--- a/train.py
+++ b/train.py
@@ -33,7 +33,6 @@ from kiliautoml.utils.memoization import clear_automl_cache
 from kiliautoml.utils.path import Path
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
-os.environ["WANDB_DISABLED"] = "true"
 
 
 def train_image_bounding_box(
@@ -142,6 +141,8 @@ def main(
 
     training_losses = []
     for job_name, job in jobs.items():
+        os.environ["WANDB_PROJECT"] = title + "_" + job_name
+
         if clear_dataset_cache:
             clear_automl_cache(
                 project_id, command="train", job_name=job_name, model_repository=model_repository


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38733898/165750258-eca1c8a3-2200-46ad-a35a-bc5f8b0ac72c.png)

- Implemented the feature for all huggingface tasks.
- On wandb, each job appears as a different project
- Each run has a name with the model name and the date.