### PR TITLE
Fixed asset parameter

### DIFF
--- a/kiliautoml/models/_hugging_face_text_classification_model.py
+++ b/kiliautoml/models/_hugging_face_text_classification_model.py
@@ -208,7 +208,7 @@ class HuggingFaceTextClassificationModel(BaseModel, HuggingFaceMixin, KiliTextPr
                     handler.write(
                         json.dumps(
                             {
-                                "text": self._get_text_from(asset["content"]),
+                                "text": self._get_text_from(asset),
                                 "label": job_categories.index(label_category),
                             }
                         )


### PR DESCRIPTION
Hello,

I tried to use the `train.py` script for a text classification task, but it failed, giving the following message:

```bash
File "PROJECT_PATH/automl/kiliautoml/models/_hugging_face_text_classification_model.py", line 213, in _write_dataset
    "text": self._get_text_from(asset["content"]),
File "PROJECT_PATH/automl/kiliautoml/mixins/_kili_text_project_mixin.py", line 18, in _get_text_from
    text = download_asset_unicode(self.api_key, asset["content"], self.project_id)
TypeError: string indices must be integers
```
I tracked the error and found that the issue is in passing the asset parameter to the download function, it receives the asset itself, but the current code is passing only the content of the asset. 