### PR TITLE
Add 2 new strategies for merge: duplicate and copy

### DIFF
--- a/kiliautoml/models/_ultralytics_object_detection.py
+++ b/kiliautoml/models/_ultralytics_object_detection.py
@@ -126,7 +126,6 @@ class UltralyticsObjectDetectionModel(BaseModel):
             title, model_repository_dir, self.model_framework
         )
         os.makedirs(model_output_path, exist_ok=True)
-
         os.makedirs(os.path.dirname(config_data_path), exist_ok=True)
         self._yaml_preparation(
             data_path=data_path,

--- a/kiliautoml/utils/type.py
+++ b/kiliautoml/utils/type.py
@@ -5,7 +5,7 @@ from typing_extensions import Literal, TypedDict
 AssetStatusT = Literal["TODO", "ONGOING", "LABELED", "TO_REVIEW", "REVIEWED"]
 LabelTypeT = Literal["PREDICTION", "DEFAULT", "AUTOSAVE", "REVIEW", "INFERENCE"]
 CommandT = Literal["train", "predict", "label_errors", "prioritize"]
-LabelMergeStrategyT = Literal["last", "first"]
+LabelMergeStrategyT = Literal["first", "last", "duplicate", "copy"]
 ContentInputT = Literal["checkbox", "radio"]
 InputTypeT = Literal["IMAGE", "TEXT"]
 ModelFrameworkT = Literal["pytorch", "tensorflow"]


### PR DESCRIPTION
For an asset labeled by n different labelers:
- duplicate: create 1 asset for every annotation of the asset (n new assets)
- copy: select 1 annotation of the asset (random) and create n new assets with that annotation