### PR TITLE
Asset filtering for eval and training

### DIFF
--- a/commands/common_args.py
+++ b/commands/common_args.py
@@ -10,7 +10,7 @@ from kiliautoml.utils.type import AssetStatusT, MLBackendT, ParityFilterT, Verbo
 DEFAULT_BATCH_SIZE = 8
 
 
-def asset_filter_loader(a, b, json_string):
+def asset_filter_loader(json_string):
     if json_string is not None:
         try:
             with open(json_string, "r") as f:
@@ -135,11 +135,11 @@ class Options:
     asset_filter = click.option(
         "--asset-filter",
         default=None,
-        callback=asset_filter_loader,
+        callback=lambda _, __, x: asset_filter_loader(x),
         help=(
-            "args assets SDK function to filter assets."
-            "See https://python-sdk-docs.kili-technology.com/latest/asset/"  # noqa
-            "Ex:  --asset-filter " + example_json_string
+            "args assets SDK function to filter assets. "
+            "See https://python-sdk-docs.kili-technology.com/latest/asset/ "  # noqa
+            "Ex:  --asset-filter " + f"'{example_json_string}"
         ),
     )
 
@@ -152,7 +152,7 @@ def asset_status_in(default: List[AssetStatusT]):
         callback=lambda _, __, x: x.upper().split(",") if x else None,
         help=(
             "Comma separated (without space) list of Kili asset status to select "
-            "among: 'TODO', 'ONGOING', 'LABELED', 'TO_REVIEW', 'REVIEWED'"
+            "among: 'TODO', 'ONGOING', 'LABELED', 'TO_REVIEW', 'REVIEWED' "
             "Example: python train.py --asset-status-in TO_REVIEW,REVIEWED "
         ),
     )

--- a/commands/common_args.py
+++ b/commands/common_args.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import List
+from typing import List, Optional
 
 import click
 from typing_extensions import get_args
@@ -10,7 +10,7 @@ from kiliautoml.utils.type import AssetStatusT, MLBackendT, ParityFilterT, Verbo
 DEFAULT_BATCH_SIZE = 8
 
 
-def asset_filter_loader(json_string):
+def asset_filter_loader(json_string: Optional[str]):
     if json_string is not None:
         try:
             with open(json_string, "r") as f:

--- a/commands/common_args.py
+++ b/commands/common_args.py
@@ -10,6 +10,15 @@ from kiliautoml.utils.type import AssetStatusT, MLBackendT, ParityFilterT, Verbo
 DEFAULT_BATCH_SIZE = 8
 
 
+def asset_filter_loader(a, b, json_string):
+    if json_string is not None:
+        try:
+            with open(json_string, "r") as f:
+                return json.load(f)
+        except FileNotFoundError:
+            return json.loads(json_string)
+
+
 class Options:
 
     project_id = click.option("--project-id", required=True, help="Kili project ID")
@@ -119,6 +128,18 @@ class Options:
             "Experimental feature. "
             "This can be used to train on even hash assets names, and test on uneven ones. "
             "This can be usefull if you want to do some tests on a project entirely labelled."
+        ),
+    )
+
+    example_json_string = '{"metadata_where": {"dataset_type": "training"}}'
+    asset_filter = click.option(
+        "--asset-filter",
+        default=None,
+        callback=asset_filter_loader,
+        help=(
+            "args assets SDK function to filter assets."
+            "See https://python-sdk-docs.kili-technology.com/latest/asset/"  # noqa
+            "Ex:  --asset-filter " + example_json_string
         ),
     )
 

--- a/commands/eval.py
+++ b/commands/eval.py
@@ -39,6 +39,7 @@ from kiliautoml.utils.type import (
 @Options.target_job
 @Options.ignore_job
 @Options.max_assets
+@Options.randomize_assets
 @Options.clear_dataset_cache
 @Options.batch_size
 @Options.verbose
@@ -56,6 +57,7 @@ def main(
     target_job: List[JobNameT],
     ignore_job: List[JobNameT],
     max_assets: Optional[int],
+    randomize_assets: bool,
     clear_dataset_cache: bool,
     batch_size: int,
     verbose: VerboseLevelT,
@@ -81,6 +83,7 @@ def main(
         project_id,
         asset_status_in,
         max_assets=max_assets,
+        randomize=randomize_assets,
     )
 
     for job_name, job in jobs.items():
@@ -105,6 +108,7 @@ def main(
             batch_size=batch_size,
             clear_dataset_cache=clear_dataset_cache,
             from_project=from_project,
+            max_assets=max_assets,
         )
         condition_requested = ModelConditionsRequested(
             input_type=input_type,

--- a/commands/eval.py
+++ b/commands/eval.py
@@ -19,6 +19,7 @@ from kiliautoml.utils.helpers import (
 )
 from kiliautoml.utils.logging import logger, set_kili_logging
 from kiliautoml.utils.type import (
+    AssetFilterArgsT,
     AssetStatusT,
     JobNameT,
     MLBackendT,
@@ -40,6 +41,7 @@ from kiliautoml.utils.type import (
 @Options.ignore_job
 @Options.max_assets
 @Options.randomize_assets
+@Options.asset_filter
 @Options.clear_dataset_cache
 @Options.batch_size
 @Options.verbose
@@ -58,6 +60,7 @@ def main(
     ignore_job: List[JobNameT],
     max_assets: Optional[int],
     randomize_assets: bool,
+    asset_filter: AssetFilterArgsT,
     clear_dataset_cache: bool,
     batch_size: int,
     verbose: VerboseLevelT,
@@ -84,6 +87,7 @@ def main(
         asset_status_in,
         max_assets=max_assets,
         randomize=randomize_assets,
+        asset_filter=asset_filter,
     )
 
     for job_name, job in jobs.items():
@@ -108,7 +112,6 @@ def main(
             batch_size=batch_size,
             clear_dataset_cache=clear_dataset_cache,
             from_project=from_project,
-            max_assets=max_assets,
         )
         condition_requested = ModelConditionsRequested(
             input_type=input_type,

--- a/commands/train.py
+++ b/commands/train.py
@@ -22,6 +22,7 @@ from kiliautoml.utils.logging import logger, set_kili_logging
 from kiliautoml.utils.memoization import clear_command_cache
 from kiliautoml.utils.type import (
     AdditionalTrainingArgsT,
+    AssetFilterArgsT,
     AssetStatusT,
     JobNameT,
     LabelMergeStrategyT,
@@ -54,6 +55,7 @@ from wandb.sdk.wandb_run import Run  # isort:skip
 @Options.verbose
 @Options.label_merge_strategy
 @Options.parity_filter
+@Options.asset_filter
 @TrainOptions.asset_status_in
 @TrainOptions.epochs
 @TrainOptions.disable_wandb
@@ -79,6 +81,7 @@ def main(
     verbose: VerboseLevelT,
     batch_size: int,
     parity_filter: ParityFilterT,
+    asset_filter: AssetFilterArgsT,
     additional_train_args_hg: AdditionalTrainingArgsT,
     additional_train_args_yolo: AdditionalTrainingArgsT,
     results_dir: Optional[str],
@@ -126,6 +129,7 @@ def main(
             strategy=label_merge_strategy,
             job_name=job_name,
             parity_filter=parity_filter,
+            asset_filter=asset_filter,
         )
 
         if clear_dataset_cache:

--- a/kiliautoml/models/_hugging_face_text_classification_model.py
+++ b/kiliautoml/models/_hugging_face_text_classification_model.py
@@ -78,6 +78,11 @@ class HuggingFaceTextClassificationModel(HuggingFaceModel, HuggingFaceMixin, Kil
 
         path_dataset = os.path.join(PathHF.dataset_dir(model_repository_dir), "data.json")
         logger.info(f"Downloading data to {path_dataset}")
+        if not clear_dataset_cache:
+            logger.warning(
+                "If you are using filter on assets, consider using --clear-dataset-cache, "
+                "to make sure that the right assets are used."
+            )
         if os.path.exists(path_dataset) and clear_dataset_cache:
             os.remove(path_dataset)
         job_categories = categories_from_job(self.job)

--- a/kiliautoml/models/_hugging_face_text_classification_model.py
+++ b/kiliautoml/models/_hugging_face_text_classification_model.py
@@ -143,14 +143,14 @@ class HuggingFaceTextClassificationModel(HuggingFaceModel, HuggingFaceMixin, Kil
         from_project: Optional[ProjectIdT],
     ) -> EvalResultsT:
 
-        _ = clear_dataset_cache
-
         model_repository_dir = Path.model_repository_dir(
             self.project_id, self.job_name, self.model_repository
         )
 
         path_dataset = os.path.join(PathHF.dataset_dir(model_repository_dir), "data.json")
         job_categories = categories_from_job(self.job)
+        if os.path.exists(path_dataset) and clear_dataset_cache:
+            os.remove(path_dataset)
         if not os.path.exists(path_dataset):
             self._write_dataset(assets, self.job_name, path_dataset, job_categories)
         dataset = datasets.load_dataset(  # type: ignore

--- a/kiliautoml/utils/helpers.py
+++ b/kiliautoml/utils/helpers.py
@@ -83,7 +83,7 @@ def get_asset_memoized(
 ) -> List[Any]:
     kili.assets = backoff.on_exception(backoff.expo, exception=Exception, max_tries=3)(kili.assets)
 
-    additional_filtering_arguments = {}
+    additional_filtering_arguments: Dict[str, Any] = {}
     if asset_filter is not None:
         additional_filtering_arguments = {}
         for argument in asset_filter.keys():
@@ -107,7 +107,6 @@ def get_asset_memoized(
                 additional_filtering_arguments[argument] = asset_filter[argument]
             else:
                 logger.warning(f"You can not filter on this field {argument}")
-
     assets = kili.assets(
         project_id=project_id,
         first=total,

--- a/kiliautoml/utils/type.py
+++ b/kiliautoml/utils/type.py
@@ -216,6 +216,7 @@ class JobPredictions:
 
 
 AdditionalTrainingArgsT = Dict[str, Any]
+AssetFilterArgsT = Dict[str, Any]
 EvalResultsT = Dict[str, Any]
 
 

--- a/tests/e2e/utils_test_e2e.py
+++ b/tests/e2e/utils_test_e2e.py
@@ -154,6 +154,9 @@ def create_arguments_test(command: CommandT, project_id, target_job=""):
             command,
             "--project-id",
             project_id,
+            "--asset-filter",
+            '{"label_created_at_gt": "2021-07-28T15:12:17.329Z"}',
+            "--clear-dataset-cache",
         ]
     else:
         raise NotImplementedError


### PR DESCRIPTION
Add asset filter similar to Kili SDK assets method that can filter on any of the following fields:
- "asset_id_in"
- "consensus_mark_gt"
- "consensus_mark_lt"
- "external_id_contains",
- "honeypot_mark_gt",
- "honeypot_mark_lt",
- "label_author_in",
- "label_created_at",
- "label_created_at_gt",
- "label_created_at_lt",
- "label_category_search",
- "label_type_in",
- "metadata_where",
- "updated_at_gte",
- "updated_at_lte"